### PR TITLE
Wire Check events to webhook parsing

### DIFF
--- a/github/activity_events.go
+++ b/github/activity_events.go
@@ -32,6 +32,10 @@ func (e Event) String() string {
 // a value of the corresponding struct type will be returned.
 func (e *Event) ParsePayload() (payload interface{}, err error) {
 	switch *e.Type {
+	case "CheckRunEvent":
+		payload = &CheckRunEvent{}
+	case "CheckSuiteEvent":
+		payload = &CheckSuiteEvent{}
 	case "CommitCommentEvent":
 		payload = &CommitCommentEvent{}
 	case "CreateEvent":

--- a/github/messages.go
+++ b/github/messages.go
@@ -41,6 +41,8 @@ const (
 var (
 	// eventTypeMapping maps webhooks types to their corresponding go-github struct types.
 	eventTypeMapping = map[string]string{
+		"check_run":                   "CheckRunEvent",
+		"check_suite":                 "CheckSuiteEvent",
 		"commit_comment":              "CommitCommentEvent",
 		"create":                      "CreateEvent",
 		"delete":                      "DeleteEvent",

--- a/github/messages_test.go
+++ b/github/messages_test.go
@@ -162,6 +162,14 @@ func TestParseWebHook(t *testing.T) {
 		messageType string
 	}{
 		{
+			payload:     &CheckRunEvent{},
+			messageType: "check_run",
+		},
+		{
+			payload:     &CheckSuiteEvent{},
+			messageType: "check_suite",
+		},
+		{
 			payload:     &CommitCommentEvent{},
 			messageType: "commit_comment",
 		},


### PR DESCRIPTION
This PR registers the new `CheckRunEvent` and `CheckSuiteEvent`s into a couple of enums that are used by in the `go-github` API. Ultimately this allows the new events to be surfaced from the `ParseWebhook` function by:

```
webhookType := github.WebHookType(r)
event, err := github.ParseWebHook(webhookType, payload)
if err != nil {
	...
}
switch event := event.(type) {
case *github.CheckSuiteEvent:
		...
```

See my comment https://github.com/google/go-github/pull/914/#issuecomment-400005742 for slightly more context.